### PR TITLE
Add an alias to ModuleKind in the exported members of ScalaJSPlugin

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -134,6 +134,9 @@ object ScalaJSPlugin extends AutoPlugin {
       new PhantomJSEnv(executable, args, env, autoExit, loader)
     }
 
+    // ModuleKind
+    val ModuleKind = org.scalajs.core.tools.linker.backend.ModuleKind
+
     // All our public-facing keys
 
     val isScalaJSProject = SettingKey[Boolean]("isScalaJSProject",

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -44,7 +44,7 @@ import java.net.URLClassLoader
  */
 object ScalaJSPluginInternal {
 
-  import ScalaJSPlugin.autoImport._
+  import ScalaJSPlugin.autoImport.{ModuleKind => _, _}
 
   /** The global Scala.js IR cache */
   val globalIRCache: IRFileCache = new IRFileCache()


### PR DESCRIPTION
The goal is to make it possible for users to name module kinds without having to import the following on top of their build.sbt:

~~~ scala
import org.scalajs.core.tools.linker.backend.ModuleKind

scalaJSModuleKind := ModuleKind.NodeJSModule
~~~

With this PR they can just write the following:

~~~ scala
scalaJSModuleKind := ModuleKind.NodeJSModule
~~~